### PR TITLE
Possible fix for issue #55

### DIFF
--- a/magicked_admin/main.py
+++ b/magicked_admin/main.py
@@ -19,7 +19,7 @@ if not os.path.exists("./magicked_admin.conf"):
     input("Press enter to exit...")
     sys.exit()
 
-config = configparser.ConfigParser()
+config = configparser.ConfigParser(strict=False)
 config.read("./magicked_admin.conf")
 
 class MagickedAdministrator:

--- a/magicked_admin/main.py
+++ b/magicked_admin/main.py
@@ -19,8 +19,13 @@ if not os.path.exists("./magicked_admin.conf"):
     input("Press enter to exit...")
     sys.exit()
 
-config = configparser.ConfigParser(strict=False)
-config.read("./magicked_admin.conf")
+# Reading the config file
+try:
+    config = configparser.ConfigParser()
+    config.read("./magicked_admin.conf")
+except configparser.DuplicateOptionError as e:
+    sys.exit("Duplicate Values found in Config! Please check options \"" + e.option + "\" for server \"" + e.section +"\".")
+
 
 class MagickedAdministrator:
     
@@ -47,11 +52,10 @@ class MagickedAdministrator:
             enable_greeter = str_to_bool(
                 config[server_name]["enable_greeter"]
             )
-
             server = Server(server_name, address, user, password,
                             game_password)
             self.servers.append(server)
-                
+
             if motd_scoreboard:
                 motd_updater = MotdUpdater(server, scoreboard_type)
                 motd_updater.start()
@@ -61,7 +65,7 @@ class MagickedAdministrator:
             server.chat.add_listener(cb)
             self.chatbots.append(cb)
 
-        print("Initialisation complete")
+            print("Initialisation complete")
             
     def terminate(self, signal, frame):
         print("Terminating, saving data...")


### PR DESCRIPTION
 Changed ConfigParser() to allow multiple config option. Now only the last option will be selected.

But as stated in the [docs](https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour) it is not recommended. It will fix the problem for now but maybe checking the config file before loading the values might be a better option.